### PR TITLE
Generalization of directories for vignetting, input, output, CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,41 @@ cmake_minimum_required(VERSION 3.17)
 project(digitazionpp VERSION 0.0.1)
 
 find_package(ROOT REQUIRED)
+find_package(OpenCV CONFIG REQUIRED)
 
 add_compile_options(-Wall -Wextra -O3)
 
-set(CMAKE_CXX_STANDARD 17)
+#Finds c++ standard from ROOT and forces it to the compiler
+if(DEFINED ROOT_CXX_FLAGS)
+    #Extract  c++std info
+    string(REGEX MATCH "-std=c\\+\\+[0-9]+" STD_FLAGS ${ROOT_CXX_FLAGS})
+    string(REGEX REPLACE "-std=c\\+\\+" "" ROOT_CXX ${STD_FLAGS})
+endif()
+
+if(ROOT_CXX STREQUAL "20")
+    set(CMAKE_CXX_STANDARD 20)
+elseif(ROOT_CXX STREQUAL "17")
+    set(CMAKE_CXX_STANDARD 17)
+else()
+    message(FATAL_ERROR "ROOT compiled with non-supported C++ version. c++17 and 20 are supported")
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(${ROOT_USE_FILE})
-include_directories(${ROOT_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
+include_directories(${ROOT_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR} ${OpenCV_INCLUDE_DIRS} $ENV{ROOTANASYS}/include)
+
+#Debug comments
+#message(ROOTANASYS="$ENV{ROOTANASYS}/include")
+#get_cmake_property(_variableNames VARIABLES)
+#foreach (_variableName ${_variableNames})
+#    if (_variableName MATCHES "ROOT")
+#        message(STATUS "${_variableName}=${${_variableName}}")
+#    endif()
+#endforeach()
+
 link_directories(${ROOT_LIBRARY_DIR}
                  "$ENV{ROOTANASYS}/lib"
-                 "$ENV{OPENCVSYS}/lib" #opencv
                 )
-
-add_executable(digitazionpp "${PROJECT_SOURCE_DIR}/MC_data_new.cxx")
-target_link_libraries(digitazionpp PUBLIC ${ROOT_LIBRARIES} s3 curl rootana cygnolib z opencv_imgcodecs opencv_core)
-
 
 # --------    s3  --------
 add_library(s3 "${PROJECT_SOURCE_DIR}/src/s3.cxx")
@@ -28,11 +47,15 @@ target_include_directories(s3 PUBLIC
                           
 # -------- cygnolib --------
 add_library(cygnolib
-           "${PROJECT_SOURCE_DIR}/src/cygnolib.cxx"
+           ${PROJECT_SOURCE_DIR}/src/cygnolib.cxx
            )
 target_include_directories(cygnolib PUBLIC
-                          "${PROJECT_BINARY_DIR}"
-                          "${PROJECT_SOURCE_DIR}/include"
-                          "$ENV{ROOTANASYS}/include"
-                          "$ENV{OPENCVSYS}/include"
+                          ${PROJECT_BINARY_DIR}
+                          ${PROJECT_SOURCE_DIR}/include
+                          $ENV{ROOTANASYS}/include
                           )
+target_link_libraries(cygnolib PUBLIC rootana z)
+
+
+add_executable(digitazionpp "${PROJECT_SOURCE_DIR}/MC_data_new.cxx")
+target_link_libraries(digitazionpp PUBLIC ${ROOT_LIBRARIES} ${OpenCV_LIBS} s3 curl rootana cygnolib z opencv_imgcodecs opencv_core)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digitization code in C++
 
 ## Dependencies
 
-* ROOT [compiled with the C++17 standard]
+* ROOT [compiled with the C++17 or C++20 standard]
 * ROOTANA [https://bitbucket.org/tmidas/rootana/src/master/]
 * OPENCV [https://docs.opencv.org/4.x/d7/d9f/tutorial_linux_install.html]
 
@@ -16,6 +16,9 @@ Before compiling, set the variables ROOTANASYS and OPENCVSYS in your environment
 
 `export OPENCVSYS="/path/to/opencv/installation/"`
 
+In the file you use to call the source of thisroot.sh (your setup file or .bashrc), add after the source of the thisroot.sh the line:
+
+`export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$OPENCVSYS`
 
 ## Installation
 
@@ -23,7 +26,7 @@ Before compiling, set the variables ROOTANASYS and OPENCVSYS in your environment
 
 `cd digitizationpp`
 
-`export CXX="/path/to/your/c++17/compiler"`
+`export CXX="/path/to/your/c++17or20/compiler"`
 
 `mkdir build-dir && cd build-dir`
 
@@ -41,12 +44,19 @@ Documentation should be then available at `doc/html/index.html`.
 
 ## Suggested usage
 
-Put all the MC `.root` files you want to digitize in the `input/` folder, then:
+Put all the MC `.root` files you want to digitize in an input folder (<input_folder>)
+Move to a desired folder where to launch the code
+
+`./<path_to_build-dir>/digitizationpp ..<path_to_digitizationpp-dir>/config/ConfigFile_new.txt -I <path_to_input_folder> -O <path_to_output_folder>`
+
+If not existing, the <outdir> will be created. The -I and -O options can be droppped and the code will search inputfiles in
+`<path_to_digitizationpp-dir>/input/`
+and the outdir will be created in 
+`<path_to_digitizationpp-dir>/OutDir/`
+
+# Example
+From `<path_to_digitizationpp-dir>`
 
 `cd build-dir`
 
 `./digitizationpp ../config/ConfigFile_new.txt`
-
-The output file will be saved in the `OutDir/` folder.
-
-

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Documentation should be then available at `doc/html/index.html`.
 Put all the MC `.root` files you want to digitize in an input folder (<input_folder>)
 Move to a desired folder where to launch the code
 
-`./<path_to_build-dir>/digitizationpp ..<path_to_digitizationpp-dir>/config/ConfigFile_new.txt -I <path_to_input_folder> -O <path_to_output_folder>`
+`./<path_to_build-dir>/digitizationpp <path_to_digitizationpp-dir>/config/ConfigFile_new.txt -I <path_to_input_folder> -O <path_to_output_folder>`
 
-If not existing, the <outdir> will be created. The -I and -O options can be droppped and the code will search inputfiles in
+If not existing, the Outdir will be created. The -I and -O options can be droppped and the code will search inputfiles in
 `<path_to_digitizationpp-dir>/input/`
 and the outdir will be created in 
 `<path_to_digitizationpp-dir>/OutDir/`


### PR DESCRIPTION
Generalization of directories for vignetting, input, output, CMakeLists.txt.

Searches the base folder of this repo and builds paths for vignetting, input and output dir from there.

Split function for string generated. Could replace in future some parts of ReadConfig

CMakeLists.txt and readme updated to exploit CMake features of OpenCV and adapt to the c++17 or 20 version with which ROOT was built