### PR TITLE
fix memory consumption with high energy ER tracks and new parameter in the config file

### DIFF
--- a/MC_data_new.cxx
+++ b/MC_data_new.cxx
@@ -1419,9 +1419,9 @@ void compute_cmos_with_saturation(vector<double>& x_hits_tr,
             long int M = y_n_bin;
             long int N = z_n_bin;
             
-            if(NR_flag==true && energy>100){
+            if((NR_flag==true && energy>100)||(NR_flag==false && energy>500)) {
                 
-                int WID = 20;
+                int WID = stoi(options["WID"]);
                 int nparts = 1 + x_hits_tr.size()/WID;
                 for(int part = 0; part < nparts; part++) {
                     cout<<"   part "<<part<<"/"<<nparts<<"..."<<endl;
@@ -1605,10 +1605,10 @@ void compute_cmos_with_saturation(vector<double>& x_hits_tr,
                                                   vector<vector<double>>(y_n_bin+1,
                                                                          vector<double>(z_n_bin+1, 0.0)));
                 
-                if(NR_flag==true && energy>100) {
+                if((NR_flag==true && energy>100)||(NR_flag==false && energy>500)) {
                     
 
-                    int WID = 20;
+                    int WID = stoi(options["WID"]);
                     int nparts = 1 + x_hits_tr.size()/WID;
                     
                     //cout<<"DEBUG "<<hc.size()<<","<<hc[0].size()<<","<<hc[0][0].size()<<endl<<flush;

--- a/config/ConfigFile_new.txt
+++ b/config/ConfigFile_new.txt
@@ -64,6 +64,7 @@
 'events'                : -1,         # number of events to be processed, -1 = all
 'donotremove'           : True,      # Remove or not the file from the tmp folder
 'fixed_seed'            : False,     # If 'True' the seed of random distributions is set to 0 (for debugging purposes)
+'WID'                   : 5,         # Integer parameter: the smaller WID is, the smaller the ram usage but the higher the time consumption
 
 'randZ_range'           : 0.,        # Track z coordinate range [mm]. Tracks will be generated uniformly between 'z_hit+randZ_range/2' and 'z_hit-randZ_range/2'
 'absorption_l'          : 1400.,     # absorption lenght in [mm]


### PR DESCRIPTION
The `WID` parameter (an integer number) is now configurable in configuration file: it is the size of the slices of the tracks during the application of the diffusion smearing and the filling of the voxels; in other words, the smaller `WID` is, the smaller the memory usage but the slower the code. Moreover now the splitting of the tracks in slices will happen also for high energy (>500 keV) ER to save ram usage.