### PR TITLE
fixed wrong orientation of z axis with respect to current Geant4 MC files

### DIFF
--- a/src/DigitizationRunner.cxx
+++ b/src/DigitizationRunner.cxx
@@ -458,7 +458,8 @@ void DigitizationRunner::processRootFiles() {
         inputtree->SetBranchAddress("y_hits", &y_hits);
         inputtree->SetBranchAddress("z_hits", &z_hits);
             
-        if(config.getBool("NR")) { // TO BE CHECK ON REAL SRIM SIMULATIONS
+        
+        if(config.getBool("SRIM")) {// TO BE CHECK ON REAL SRIM SIMULATIONS
             inputtree->SetBranchAddress("particle_type", &particle_type);
             inputtree->SetBranchAddress("ekin_particle", &ekin_particle);
         }
@@ -726,9 +727,10 @@ void DigitizationRunner::processRootFiles() {
                     transform(x_hits->begin(),
                                 x_hits->end(),
                                 back_inserter(z_hits_tr),
-                                [&] (double a) {return a + config.getDouble("z_offset");});
+                                [&] (double a) {return -a + config.getDouble("z_offset");});
+                    // NOTE: in Geant longitunal TPC axis is towards the GEMs, for the digi it's
+                    // assume it's towards the cathode
                     
-                    // FIXME: [Check which is the z axis orientation]
                         
                 }
                     

--- a/src/TrackProcessor.cxx
+++ b/src/TrackProcessor.cxx
@@ -689,6 +689,14 @@ vector<double> TrackProcessor::NelGEM2(const vector<double>& energyDep, const ve
     vector<double> drift_l;
     int opt_gem=config.getDouble("z_extra");
     transform(z_hit.begin(),z_hit.end(),back_inserter(drift_l), [&] (double a) { return a+opt_gem;});
+
+    // Check if hits with negative drift length
+    vector<bool> negatives(drift_l.size());
+    transform(drift_l.begin(), drift_l.end(), negatives.begin(),
+              [](int x) { return x < 0; });
+    if (any_of(negatives.begin(), negatives.end(), [](bool b) { return b; })) {
+        throw runtime_error("TrackProcessor::NelGEM2: track contains hits with negative drift length.\n");
+    }
     
     vector<double> n_ioniz_el_mean(n_ioniz_el_ini.size(), 0.0);
     


### PR DESCRIPTION
Main changes:
* fixed wrong orientation of z axis with respect to current Geant4 MC files
* added a check for the presence of hits with negative drift length
* fixed warning when opening regular Geant4 files