### PR TITLE
Inclusion of redpix in the output tree

### DIFF
--- a/config/ConfigFile_new.txt
+++ b/config/ConfigFile_new.txt
@@ -75,5 +75,6 @@
 'WID'                   : 5,         # Integer parameter: the smaller WID is, the smaller the ram usage but the higher the time consumption
 'Parallel_threads'      : 8,         # Integer parameter: number of threads to use in parallel calculation
 'queue'                 : 0,	     # If you are sending to the CNAF queue write 1. The outputfiles will be forced to be written in local folder to be sent to cloud
+'redpix_output'         : False,      # True if you want the output format being the redpixes instead of images. NOTE: this will change the output namefile to "digi_RunXXXXX.root"
 
 }

--- a/include/DigitizationRunner.h
+++ b/include/DigitizationRunner.h
@@ -141,6 +141,28 @@ private:
      *         - second: a double representing the sign (1.0 or -1.0)
      */
      std::pair<char, double> getAxisMapping(const std::string& axis_label);
+
+
+     /**
+     * @brief Fills redpix data from a 2D image.
+     *
+     * Scans all bins of the input vector<vector<double>> and identifies bins with non-zero content.
+     * For each such bin, the method stores:
+     * - the X bin index in `redpix_ix`
+     * - the Y bin index in `redpix_iy`
+     * - the bin content in `redpix_iz`
+     *
+     * All output vectors are cleared at the beginning of the method.
+     *
+     * @param image     A vector<vector<double>> representing the image to analyze.
+     * @param redpix_ix Pointer to a vector to be filled with X bin indices of non-zero pixels.
+     * @param redpix_iy Pointer to a vector to be filled with Y bin indices of non-zero pixels.
+     * @param redpix_iz Pointer to a vector to be filled with bin contents (e.g., charge or intensity).
+     */
+     void FillRedpix(const std::vector<std::vector<double>>& image,
+                     std::vector<uint16_t>* redpix_ix,
+                     std::vector<uint16_t>* redpix_iy,
+                     std::vector<uint16_t>* redpix_iz);
  
      ConfigManager config;           ///< Configuration manager
      std::string configFile;         ///< Path to the config file

--- a/src/DigitizationRunner.cxx
+++ b/src/DigitizationRunner.cxx
@@ -360,6 +360,35 @@ pair<char, double> DigitizationRunner::getAxisMapping(const string& axis_label) 
     return make_pair(axis, sign);
 }
 
+void DigitizationRunner::FillRedpix(const std::vector<std::vector<double>>& image,
+                                   std::vector<uint16_t>* redpix_ix,
+                                   std::vector<uint16_t>* redpix_iy,
+                                   std::vector<uint16_t>* redpix_iz)
+{
+    redpix_ix->clear();
+    redpix_iy->clear();
+    redpix_iz->clear();
+
+    const int nRows = image.size();
+    const int nCols = image[0].size();
+
+    for (int ix = 0; ix < nRows; ++ix) {
+        for (int iy = 0; iy < nCols; ++iy) {
+            double content = image[ix][iy];
+            if (content != 0.0) {
+                redpix_ix->push_back(static_cast<uint16_t>(ix));
+                redpix_iy->push_back(static_cast<uint16_t>(iy));
+                redpix_iz->push_back(static_cast<uint16_t>(content));
+                
+            }
+        }
+    }
+    return;
+}
+
+
+
+
 
 
 // ================================================================================================
@@ -495,12 +524,21 @@ void DigitizationRunner::processRootFiles() {
         int digipart = 0;
         
         while(fileStillToDigitize) {
-            
-            // standard: name of output file = histograms_RunRRRRR.root (R run number)
+
+            // Name of output file
+            // standard:       histograms_RunRRRRR.root (R run number)
+            // redpix_ouput:         digi_RunRRRRR.root (R run number)
             if(config.getBool("queue")) fnameoutfolder="./";
-            string fileoutname= Form("%s/histograms_Run%05d.root",
-                                     fnameoutfolder.c_str(),
-                                     runCount);
+            string fileoutname = "";
+            if(config.getBool("redpix_output")) {
+                fileoutname= Form("%s/digi_Run%05d.root",
+                                  fnameoutfolder.c_str(),
+                                  runCount);
+            } else {
+                fileoutname= Form("%s/histograms_Run%05d.root",
+                                  fnameoutfolder.c_str(),
+                                  runCount);
+            }
     
     
             auto outfile = shared_ptr<TFile> {TFile::Open(fileoutname.c_str(),
@@ -544,6 +582,11 @@ void DigitizationRunner::processRootFiles() {
             Float_t z_min_cut = -1;
             Float_t z_max_cut = -1;
             Float_t proj_track_2D_cut = -1;
+
+            int nRedpix;
+            vector<uint16_t>*   redpix_ix = new vector<uint16_t>();
+            vector<uint16_t>*   redpix_iy = new vector<uint16_t>();
+            vector<uint16_t>*   redpix_iz = new vector<uint16_t>();
                 
             auto outtree = new TTree("event_info", "event_info");
                 
@@ -583,13 +626,22 @@ void DigitizationRunner::processRootFiles() {
                 outtree->Branch("z_max_cut", &z_max_cut, "z_max_cut/F");
                 outtree->Branch("proj_track_2D_cut", &proj_track_2D_cut, "proj_track_2D_cut/F");
             }
+            // Create branches for redpixes
+            outtree->Branch("nRedpix", &nRedpix, "nRedpix/I");
+            outtree->Branch("redpix_ix", &redpix_ix);
+            outtree->Branch("redpix_iy", &redpix_iy);
+            outtree->Branch("redpix_iz", &redpix_iz);
 
             int start = firstentry + digipart * NMAX_EVENTS;
             int stop  = start + NMAX_EVENTS-1;
             if(stop >= lastentry) stop = lastentry;
             for(int entry = start; entry <= stop; entry++) { // RUNNING ON ENTRIES
                 cout<<"DEBUG: Digitizing entry "<<entry<<", digipart = "<<digipart<<"..."<<endl;
-
+                if(config.getBool("redpix_output")) {
+                    redpix_ix->clear();
+                    redpix_iy->clear();
+                    redpix_iz->clear();
+                }
                 
                 
                 inputtree->GetEntry(entry);
@@ -691,10 +743,15 @@ void DigitizationRunner::processRootFiles() {
                             final_image.SetBinContent(xx+1, yy+1, background[xx][yy]);
                         }
                     }
-                        
+
+                    // Make sure nRedpix matches
+                    nRedpix = redpix_ix->size();
+                    
                     outtree->Fill();
                     outfile->cd();
-                    final_image.Write();
+                    if(!config.getBool("redpix_output")) {
+                        final_image.Write();
+                    }
                     
                     continue;
                 }
@@ -936,10 +993,17 @@ void DigitizationRunner::processRootFiles() {
                                 final_image.SetBinContent(xx+1, yy+1, background[xx][yy]);
                             }
                         }
+                        // Make sure nRedpix matches
+                        if(config.getBool("redpix_output")) {
+                            
+                            nRedpix = redpix_ix->size();
+                        }
                         
                         outtree->Fill();
                         outfile->cd();
-                        final_image.Write();
+                        if(!config.getBool("redpix_output")) {
+                            final_image.Write();
+                        }
                         
                         continue;
                     }
@@ -960,6 +1024,7 @@ void DigitizationRunner::processRootFiles() {
                                                         NR_flag,
                                                         array2d_Nph
                                                         );
+                    
                 } else {// no saturation
                     processTrack.computeWithoutSaturation(x_hits_tr,
                                                         y_hits_tr,
@@ -983,6 +1048,7 @@ void DigitizationRunner::processRootFiles() {
                                                 VignMap);
                 }
                 
+                FillRedpix(array2d_Nph, redpix_ix, redpix_iy, redpix_iz);
                 
                 if (config.getBool("exposure_time_effect")) { //cut the track post-smearing
                     if (randcut<readout_time) {
@@ -1080,10 +1146,16 @@ void DigitizationRunner::processRootFiles() {
                                 final_image_cut.SetBinContent(xx+1, yy+1, background[xx][yy]);
                             }
                         }
-                            
+                        
+                        // Make sure nRedpix matches
+                        nRedpix = redpix_ix->size();
+                        
                         outtree->Fill();
                         outfile->cd();
-                        final_image_cut.Write();
+                        if(!config.getBool("redpix_output")) {
+                            final_image_cut.Write();
+                        }
+                        
                             
                         continue;
                     }
@@ -1145,12 +1217,15 @@ void DigitizationRunner::processRootFiles() {
                 std::chrono::duration<double> durtmp=tb-ta;
                 cout << "Time taken in seconds to compute_cmos_with_saturation is: " << durtmp.count() << endl;
                     
-                    
+                // Make sure nRedpix matches
+                nRedpix = redpix_ix->size();
+                
                 outtree->Fill();
                 outfile->cd();
-                
                 // DEBUG
-                final_image.Write();
+                if(!config.getBool("redpix_output")) {
+                    final_image.Write();
+                }
             }
             //outfile->cd("event_info");
             outtree->Write();


### PR DESCRIPTION
Redpix have been included in the output `event_info` tree with the following characteristics:
* they have the same names and the same vector-like structure as in the recofiles
* they all are saved as `std::vector<uint16_t>`, i.e. 16 bit unsigned integers, as the intensity of the pixels as output of the digitization are instrinsically integers

A new flag `redpix_output` in config file to generate output file either with or without the TH2F images:
* if the flag `redpix_output` is `True` then the output file will be named `digi_RunXXXXX.root` and **will not** contain the `TH2F` histograms
* if the flag `redpix_output` is `False` then the output file will be named `histograms_RunXXXXX.root` and **will** contain the `TH2F` histograms