### PR TITLE
Redpix conclusive upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,13 @@ add_executable(digitizationpp
                )
 target_link_libraries(digitizationpp PUBLIC ${ROOT_LIBRARIES} ${OpenCV_LIBS} s3 curl rootana cygnolib z opencv_imgcodecs opencv_core tbb)
 
-add_executable(joinPeds "${PROJECT_SOURCE_DIR}/joinPeds.cxx")
-target_link_libraries(joinPeds PUBLIC ${ROOT_LIBRARIES} ${OpenCV_LIBS} s3 curl rootana cygnolib z opencv_imgcodecs opencv_core)
+add_executable(joinPeds
+               "${PROJECT_SOURCE_DIR}/joinPeds.cxx"
+               "${PROJECT_SOURCE_DIR}/src/ConfigManager.cxx"
+               "${PROJECT_SOURCE_DIR}/src/DigitizationRunner.cxx"
+               "${PROJECT_SOURCE_DIR}/src/Globals.cxx"#
+               "${PROJECT_SOURCE_DIR}/src/TrackProcessor.cxx"
+               "${PROJECT_SOURCE_DIR}/src/Utils.cxx"
+               )
+target_link_libraries(joinPeds PUBLIC ${ROOT_LIBRARIES} ${OpenCV_LIBS} s3 curl rootana cygnolib z opencv_imgcodecs opencv_core tbb)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ and the outdir will be created in
 
 Depending on the system, the outdir folder creation may fail. In that case create the output directory.
 
+The code supports the possibility of generating, via the flag `redpix_output` in the config file, an output file that does not contain TH2I images, but just the redpix-equivalent of the digitised tracks (they are located in the `event_info` tree of the output file). If this is the case the output file will be named `digi_RunXXXXX.root` - instead of the usual `histograms_RunXXXXX.root` convention. In order to generate a `histograms_RunXXXXX.root` file from the `digi_RunXXXXX.root` file (e.g. if you want to reconstruct digitized events), you should run the `joinPeds` executable - which is automatically compiled and generated in the same directory of `digitizationpp` if you followed the installation instructions reported above - with the following suggested usage:
+
+`./<path_to_build-dir>/joinPeds <path_to_digitizationpp-dir>/config/ConfigFile_new.txt -I <path_to_digi_Run_folder> -O <path_to_output_folder>`
+
+As for `digitizationpp`, if not existing, the Outdir will be created. The -I and -O options can be droppped and the code will search `digi_RunXXXXX.root` input files in
+`<path_to_digitizationpp-dir>/OutDir/`
+and the outdir will be created in 
+`<path_to_digitizationpp-dir>/OutDir/`
+
 ## Digitization reference frame
 
 The reference frame (RF) used in digitization is the following:

--- a/include/DigitizationRunner.h
+++ b/include/DigitizationRunner.h
@@ -45,6 +45,11 @@ public:
      */
     void run();
 
+    /**
+     * @brief Executes the addition of random pedestals to input "digi_RunXXXXX.root" file.
+     */
+     void runPedsOnly();
+
 private:
 
     /**
@@ -73,7 +78,35 @@ private:
       * @return True if valid, false otherwise.
       */
      bool isValidInputFile(const std::string& filename) const;
- 
+    
+     /**
+     * @brief Checks if the input filename matches the expected digi file format.
+     *
+     * Validates whether the provided filename follows the naming convention:
+     * `digi_RunXXXXX.root`, where `XXXXX` is a number with 5 or more digits.
+     *
+     * @param[in] filename The name of the file to validate.
+     * @return true if the filename matches the expected format; false otherwise.
+     *
+     * @note This check uses a regular expression internally.
+     */
+     bool isValidDigiFile(const std::string& filename) const;
+
+     /**
+     * @brief Extracts the run number from a digi file name.
+     *
+     * Parses a filename of the form `digi_RunXXXXX.root` and extracts the numeric
+     * run number (where `XXXXX` is a number with 5 or more digits).
+     *
+     * @param[in] filename The digi file name to parse.
+     * @return The extracted run number as an integer.
+     *
+     * @throws std::invalid_argument if the filename does not match the expected format.
+     *
+     * @see isValidDigiFile() to validate the filename before calling this.
+     */
+     int extractDigiRunNumber(const std::string& filename);
+
      /**
       * @brief Sets the random seed for reproducibility.
       * @param[in] seed Seed value (default is 10).
@@ -124,6 +157,22 @@ private:
      void AddBckg(std::vector<std::vector<int>>& background);
 
      /**
+     * @brief Adds pedestal histograms to the "param_dir" directory of the output ROOT file.
+     *
+     * This function assumes that the output ROOT file (`outfile`) already contains a
+     * directory named "param_dir", and that this directory holds existing TH1 histograms.
+     * It adds pedestal run numbers to `pedestal_runs` TH1F.
+     *
+     *
+     * @param[in] outfile A shared pointer to the output ROOT file where the histograms
+     *                    will be modified or augmented.
+     *
+     * @note This function modifies the ROOT file in-place, and the changes are saved
+     *       directly into `outfile`.
+     */
+     void addPedsToParamDir(std::shared_ptr<TFile>& outfile);
+
+     /**
      * @brief Parses a MC axis label string and returns the corresponding digititazion axis and sign.
      *
      * This function interprets a string like "x", "-y", or "z" to determine which
@@ -163,6 +212,19 @@ private:
                      std::vector<uint16_t>* redpix_ix,
                      std::vector<uint16_t>* redpix_iy,
                      std::vector<uint16_t>* redpix_iz);
+
+    /**
+     * @brief Generates TH2I from a digi ROOT file.
+     *
+     * This function processes a ROOT file named `digi_RunXXXXX.root`, where `XXXXX`
+     * represents the run number, and creates a new output ROOT file called
+     * `histograms_RunXXXXX.root`. The output file contains TH2F histograms that
+     * visualize the tracks recorded in the input digi file.
+     *
+     * @note The function assumes the input file follows the naming convention
+     *       `digi_RunXXXXX.root` and outputs histograms accordingly.
+     */
+     void generateHistogramsFromDigi();
  
      ConfigManager config;           ///< Configuration manager
      std::string configFile;         ///< Path to the config file

--- a/include/TrackProcessor.h
+++ b/include/TrackProcessor.h
@@ -206,6 +206,21 @@ private:
      */
     double Nph_saturation(int nel, double A, double beta);
 
+    /**
+    * @brief Maps string variable names to integer codes for track variable dispatch.
+    *
+    * This map is used to associate human-readable variable names (e.g., "x_vertex", "z_max")
+    * with unique integer codes. These codes are used in a switch-case structure to
+    * efficiently dispatch computation logic in the TrackProcessor::GetTrackVariable function.
+    *
+    * @note This structure allows converting slow if-else chains into fast integer-based
+    *       lookups and switch-case branching.
+    *
+    * Example:
+    * @code
+    * int varcode = varname_map["x_vertex"];  // Returns 1
+    * @endcode
+    */
     std::map<std::string, int> varname_map = {
         {"proj_track_2D",  0},
         {"x_vertex",       1},

--- a/include/TrackProcessor.h
+++ b/include/TrackProcessor.h
@@ -76,6 +76,39 @@ public:
      */
     void TrackVignetting(std::vector<std::vector<double>>& image, int xpix, int ypix, const TH2F& VignMap);
 
+
+    /**
+     * @brief Applies exposure cut to digitized image and hits
+     *
+     * @param[in] image 2D image filled with the simulated event without pedestal
+     * @param[in] x_hits_tr Vector of x coordinates of energy deposits.
+     * @param[in] y_hits_tr Vector of y coordinates of energy deposits.
+     * @param[in] z_hits_tr Vector of z coordinates of energy deposits.
+     * @param[in] energy_hits_tr Energy deposited at each hit.
+     *
+     * @return The row of the image at which the cut happens
+     */
+    int ApplyExposureCut(std::vector<std::vector<double>>& image,
+                         std::vector<double>& x_hits_tr,
+                         std::vector<double>& y_hits_tr,
+                         std::vector<double>& z_hits_tr,
+                         std::vector<double>& energy_hits_tr);
+
+    /**
+     * @brief Get track variables  from variable name
+     *
+     * @param[in] varname Name of the variable to retrieve.
+     * @param[in] x_hits_tr Vector of x coordinates of energy deposits.
+     * @param[in] y_hits_tr Vector of y coordinates of energy deposits.
+     * @param[in] z_hits_tr Vector of z coordinates of energy deposits.
+     *
+     * @return The track variable specified as an input
+     */
+     double GetTrackVariable(const std::string& varname,
+                             std::vector<double>& x_hits_tr,
+                             std::vector<double>& y_hits_tr,
+                             std::vector<double>& z_hits_tr);
+
 private:
     ConfigManager& config; ///< Reference to configuration
 
@@ -172,6 +205,22 @@ private:
      * @return Saturated output value.
      */
     double Nph_saturation(int nel, double A, double beta);
+
+    std::map<std::string, int> varname_map = {
+        {"proj_track_2D",  0},
+        {"x_vertex",       1},
+        {"y_vertex",       2},
+        {"z_vertex",       3},
+        {"x_vertex_end",   4},
+        {"y_vertex_end",   5},
+        {"z_vertex_end",   6},
+        {"x_min",          7},
+        {"x_max",          8},
+        {"y_min",          9},
+        {"y_max",         10},
+        {"z_min",         11},
+        {"z_max",         12}
+    };
 
 
 

--- a/joinPeds.cxx
+++ b/joinPeds.cxx
@@ -7,115 +7,65 @@
  *
  */
 
-#include <iostream>
-#include <unistd.h>
-#include <limits.h>
-#include <sstream>
-#include <fstream>
-#include <chrono>
-#include <map>
-#include <random>
-#include <string>
-//#include <execution>
-#include <numeric>
-#include <algorithm>
-#include <cmath>
-#include <stdio.h>
-#include <cstdlib>
-#include <filesystem>
-#include <memory>
-#include "TRandom3.h"
-#include "TFile.h"
-#include "TTree.h"
-#include "TH1.h"
-#include "TH2.h"
-#include "s3.h"
-#include "cygnolib.h"
-
-using namespace std;
-
-vector<string> split(const string& , char );
-void ReadConfig(string name, map<string,string>& options);
-
-int main(int argc, char** argv)
-{
-    
-    if(argc<2) {cerr<<"No Configfile given!!\nSuggested use: ./progname.exe Configfile -I inputdir -O outputdir"; exit(EXIT_FAILURE);}
-    string nome=argv[1];
-    
-    vector<string> path_to_config=split(nome,'/');
-    string parte= "";
-    for(unsigned int i=0;i<path_to_config.size()-2;i++) parte=parte+path_to_config[i]+ "/";
-    char buffer[PATH_MAX];
-    char* ret = getcwd(buffer,sizeof(buffer));
-    if(!ret) {
-        cerr << "Failed to get current directory... exiting" << endl;
-        return EXIT_FAILURE;
-    }
-    string currentPath(buffer);
-    const string SOURCE_DIR= currentPath+"/"+parte;
-    
-    map<string,string> options;
-    ReadConfig(nome,options);
-    
-    
-    string tmpfolder = options["bckg_path"];
-    string tmpname   = options["bckg_name"];
-    
-    if(! filesystem::exists(tmpfolder)){
-        //DEBUG
-        cout<<"Creating tmpfolder..."<<
-        system(("mkdir " + tmpfolder).c_str() );
-    }
-    
-    if(! filesystem::exists(tmpfolder+tmpname)) {
-        
-        vector<int> pedruns;
-        
-        stringstream ssruns(options["noiserun"]);
-        string run;
-        vector<string> seglist;
-        while(getline(ssruns, run, ';')) {
-            int runi = stoi(run);
-            pedruns.push_back(runi);
-        }
-        
-        cygnolib::joinMidasPedestals(pedruns, options["ped_cloud_dir"], tmpfolder, tmpname);
-        
-    }
-    
-    return 0;
-    
-}
-
-// ====== FUNCTIONS DEFINITION ======
-vector<string> split(const string& str, char delimiter)
-{
-    vector<string> tokens;
-    istringstream stream(str);
-    string token;
-
-    while(getline(stream,token,delimiter)) tokens.push_back(token);
-
-    return tokens;
-}
-void ReadConfig(string name, map<string,string>& options)
-{
-    ifstream config(name.c_str());
-    
-    string line;
-    while(getline(config,line))
-    {
-        line.erase(remove_if(line.begin(),line.end(),[] (char c){return isspace(c);}),line.end());
-        line.erase(remove_if(line.begin(),line.end(),[] (char c){return c=='\'';}),line.end());
-        if(line[0] == '#' || line.empty() || line[0] == '{' || line[0] == '}') continue;
-        
-        auto delim1= line.find(":");
-        auto delim2= line.find(",");
-        if(delim2==string::npos) delim2=line.size();
-        auto index= line.substr(0,delim1);
-        auto val= line.substr(delim1+1,min(delim2,line.size())-delim1-1 );
-        options[index]=val;
-    }
-    
-}
+ #include "ConfigManager.h"
+ #include "DigitizationRunner.h"
+ 
+ #include <iostream>
+ #include <unistd.h>
+ #include <limits.h>
+ #include <filesystem>
+ 
+ using namespace std;
+ 
+ int main(int argc, char** argv) {
+     if (argc < 2) {
+         cerr << "No Configfile given!\nUsage: ./mc_sim Configfile -I inputDir -O outputDir" << endl;
+         return EXIT_FAILURE;
+     }
+ 
+     string configFile = argv[1];
+     string inputDir, outputDir;
+ 
+     // Handle optional input/output dirs
+     if (argc == 6) {
+         string arg2 = argv[2];
+         string val2 = argv[3];
+         string arg3 = argv[4];
+         string val3 = argv[5];
+ 
+         if (arg2 == "-I" && arg3 == "-O") {
+             inputDir = val2;
+             outputDir = val3;
+         } else if (arg2 == "-O" && arg3 == "-I") {
+             outputDir = val2;
+             inputDir = val3;
+         } else {
+             cerr << "Invalid argument structure. Use -I inputDir -O outputDir" << endl;
+             return EXIT_FAILURE;
+         }
+     } else {
+         // default fallback: current working directory + relative paths
+         char cwd[PATH_MAX];
+         char* ret = getcwd(cwd, sizeof(cwd));
+         if(!ret) {
+             cerr << "Failed to get current directory... exiting" << endl;
+             return EXIT_FAILURE;
+         }
+         string base = std::filesystem::path(configFile).parent_path().string();
+         inputDir = string(cwd) + "/" + base + "/../OutDir/";
+         outputDir = string(cwd) + "/" + base + "/../OutDir/";
+     }
+ 
+     
+     
+     try {
+         DigitizationRunner runner(configFile, inputDir, outputDir);
+         runner.runPedsOnly();
+     } catch (const std::exception& e) {
+         cerr << "Error during joinPeds: " << e.what() << endl;
+         return EXIT_FAILURE;
+     }
+ 
+     return EXIT_SUCCESS;
+ }
+ 

--- a/src/DigitizationRunner.cxx
+++ b/src/DigitizationRunner.cxx
@@ -729,7 +729,6 @@ void DigitizationRunner::processRootFiles() {
                 vector<vector<int>> background(x_pix,
                                                 vector<int>(y_pix, 0));        
                 AddBckg(background);
-
       
                 if (energy < config.getDouble("ion_pot")){
                     energy = 0;
@@ -759,6 +758,7 @@ void DigitizationRunner::processRootFiles() {
                 vector<double> y_hits_tr;
                 vector<double> z_hits_tr;
                 
+                // Coordinate transformation
 
                 if (config.getBool("SRIM")) {
                     // x_hits_tr = np.array(tree.x_hits) + opt.x_offset
@@ -863,9 +863,10 @@ void DigitizationRunner::processRootFiles() {
                 //    }
                 //}
                 
+                // Definition of energy hits
                 vector<double> energy_hits = (*energyDep_hits);
                     
-                // add random Z to tracks
+                // Add random Z to tracks
                 if (config.getDouble("randZ_range") != 0) {
                     double rand = (gRandom->Uniform() - 0.5) * config.getDouble("randZ_range");
                     //DEBUG
@@ -876,137 +877,27 @@ void DigitizationRunner::processRootFiles() {
                     
                 }
                 
-                //Compute length and extremes of the track before the cut
-                proj_track_2D = 0;
-                for(int ihit=0; ihit < numhits-1; ihit++){
-                    proj_track_2D += sqrt((x_hits_tr[ihit+1]-x_hits_tr[ihit])*(x_hits_tr[ihit+1]-x_hits_tr[ihit])+
-                                            (y_hits_tr[ihit+1]-y_hits_tr[ihit])*(y_hits_tr[ihit+1]-y_hits_tr[ihit])
-                                            );
-                }
-                // DEBUG
+                //Compute length and extremes of the complete track
+                proj_track_2D = processTrack.GetTrackVariable("proj_track_2D", x_hits_tr, y_hits_tr, z_hits_tr);
+                x_vertex      = processTrack.GetTrackVariable("x_vertex", x_hits_tr, y_hits_tr, z_hits_tr);
+                y_vertex      = processTrack.GetTrackVariable("y_vertex", x_hits_tr, y_hits_tr, z_hits_tr);
+                z_vertex      = processTrack.GetTrackVariable("z_vertex", x_hits_tr, y_hits_tr, z_hits_tr);
+                x_vertex_end  = processTrack.GetTrackVariable("x_vertex_end", x_hits_tr, y_hits_tr, z_hits_tr);
+                y_vertex_end  = processTrack.GetTrackVariable("y_vertex_end", x_hits_tr, y_hits_tr, z_hits_tr);
+                z_vertex_end  = processTrack.GetTrackVariable("z_vertex_end", x_hits_tr, y_hits_tr, z_hits_tr);
+                x_min = processTrack.GetTrackVariable("x_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                x_max = processTrack.GetTrackVariable("x_max", x_hits_tr, y_hits_tr, z_hits_tr);
+                y_min = processTrack.GetTrackVariable("y_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                y_max = processTrack.GetTrackVariable("y_max", x_hits_tr, y_hits_tr, z_hits_tr);
+                z_min = processTrack.GetTrackVariable("z_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                z_max = processTrack.GetTrackVariable("z_max", x_hits_tr, y_hits_tr, z_hits_tr);
+                //DEBUG
                 //cout<<"proj_track_2D = "<<Form("%.10f", proj_track_2D)<<endl;
-                    
-                    
-                x_vertex = (x_hits_tr[0] + 0.5 * config.getDouble("x_dim") )*static_cast<double>(x_pix)/config.getDouble("x_dim"); //in pixels
-                y_vertex = (y_hits_tr[0] + 0.5 * config.getDouble("y_dim") )*static_cast<double>(y_pix)/config.getDouble("y_dim"); //in pixels
-                z_vertex = (z_hits_tr[0]+config.getDouble("z_extra")); //distance from GEMs in mm
-                // DEBUG
                 //cout<<"x_vertex = "<<x_vertex<<" ### y_vertex = "<<y_vertex<<" ### z_vertex = "<<z_vertex<<endl;
-                    
-                x_vertex_end = (x_hits_tr[numhits-1] + 0.5 * config.getDouble("x_dim")) * static_cast<double>(x_pix) / config.getDouble("x_dim"); //in pixels
-                y_vertex_end = (y_hits_tr[numhits-1] + 0.5 * config.getDouble("y_dim")) * static_cast<double>(y_pix) / config.getDouble("y_dim"); //in pixels
-                z_vertex_end = (z_hits_tr[numhits-1]+config.getDouble("z_extra")); //distance from GEMs in mm
-                //DEBUG
                 //cout<<"x_vertex_end = "<<x_vertex_end<<" ### y_vertex_end = "<<y_vertex_end<<" ### z_vertex_end = "<<z_vertex_end<<endl;
-                    
-                x_min = (*min_element(x_hits_tr.begin(), x_hits_tr.end()) + 0.5 * config.getDouble("x_dim")) * static_cast<double>(x_pix) / config.getDouble("x_dim");
-                x_max = (*max_element(x_hits_tr.begin(), x_hits_tr.end()) + 0.5 * config.getDouble("x_dim")) * static_cast<double>(x_pix) / config.getDouble("x_dim");
-                y_min = (*min_element(y_hits_tr.begin(), y_hits_tr.end()) + 0.5 * config.getDouble("y_dim")) * static_cast<double>(y_pix) / config.getDouble("y_dim");
-                y_max = (*max_element(y_hits_tr.begin(), y_hits_tr.end()) + 0.5 * config.getDouble("y_dim")) * static_cast<double>(y_pix) / config.getDouble("y_dim");
-                z_min = min((*max_element(z_hits_tr.begin(),
-                                                z_hits_tr.end()) + config.getDouble("z_extra")),
-                            (*min_element(z_hits_tr.begin(),
-                                                z_hits_tr.end()) + config.getDouble("z_extra")));
-                z_max = max((*max_element(z_hits_tr.begin(),
-                                                z_hits_tr.end()) + config.getDouble("z_extra")),
-                            (*min_element(z_hits_tr.begin(),
-                                                z_hits_tr.end()) + config.getDouble("z_extra")));
-                //DEBUG
                 //cout<<" x_min = "<<x_min<<" x_max = "<<x_max<<" y_min = "<<y_min<<" y_max = "<<y_max<<" z_min = "<<z_min<<" z_max = "<<z_max<<endl;
-                
-                
-                //CUT TRACKS due to exposure of camera
-                double randcut = gRandom->Uniform(config.getDouble("exposure_time")+readout_time);
-                //randcut = 390.0;
                     
-                if (config.getBool("exposure_time_effect")) {
-                    if (randcut<readout_time) {
-                            
-                        double y_cut_tmp = config.getDouble("y_dim") * (0.5 - randcut/readout_time)-3.;
-                        
-                        // Removing elements from x_hits_tr
-                        x_hits_tr.erase(std::remove_if(x_hits_tr.begin(), x_hits_tr.end(), [&](const double& x) {
-                            return y_hits_tr[&x-&*x_hits_tr.begin()] < y_cut_tmp;
-                        }), x_hits_tr.end());
-                        // Removing elements from z_hits_tr
-                        z_hits_tr.erase(std::remove_if(z_hits_tr.begin(), z_hits_tr.end(), [&](const double& z) {
-                            return y_hits_tr[&z-&*z_hits_tr.begin()] < y_cut_tmp;
-                        }), z_hits_tr.end());
-                        // Removing elements from energy_hits
-                        energy_hits.erase(std::remove_if(energy_hits.begin(), energy_hits.end(), [&](const double& e) {
-                            return y_hits_tr[&e-&*energy_hits.begin()] < y_cut_tmp;
-                        }), energy_hits.end());
-                            
-                        // Removing elements from y_hits_tr [must be done after the previous ones]
-                        y_hits_tr.erase(std::remove_if(y_hits_tr.begin(), y_hits_tr.end(),[&](const double& y) {
-                            return y < y_cut_tmp;
-                        }), y_hits_tr.end());
-                            
-                        row_cut = y_pix - (int)(randcut * static_cast<double>(y_pix) / readout_time);
-                            
-                        //DEBUG
-                        //cout<<"y_cut_tmp = "<<y_cut_tmp<<endl;
-                        //cout<<"row_cut = "<<row_cut<<endl;
-                        //cout<<"sizes = ["<< x_hits_tr.size()<<","<<y_hits_tr.size()<<","
-                        //    <<z_hits_tr.size()<<","<<energy_hits.size()<<"]"<<endl;
-                        
-                    } else if (randcut>config.getDouble("exposure_time")) {
-                        double y_cut_tmp = config.getDouble("y_dim") * (0.5 - (randcut - config.getDouble("exposure_time")) / readout_time)+3.;
-                            
-                        // Removing elements from x_hits_tr
-                        x_hits_tr.erase(std::remove_if(x_hits_tr.begin(), x_hits_tr.end(), [&](const double& x) {
-                            return y_hits_tr[&x-&*x_hits_tr.begin()] > y_cut_tmp;
-                        }), x_hits_tr.end());
-                        // Removing elements from z_hits_tr
-                        z_hits_tr.erase(std::remove_if(z_hits_tr.begin(), z_hits_tr.end(), [&](const double& z) {
-                            return y_hits_tr[&z-&*z_hits_tr.begin()] > y_cut_tmp;
-                        }), z_hits_tr.end());
-                        // Removing elements from energy_hits
-                        energy_hits.erase(std::remove_if(energy_hits.begin(), energy_hits.end(), [&](const double& e) {
-                            return y_hits_tr[&e-&*energy_hits.begin()] > y_cut_tmp;
-                        }), energy_hits.end());
-                            
-                        // Removing elements from y_hits_tr [must be done after the previous ones]
-                        y_hits_tr.erase(std::remove_if(y_hits_tr.begin(), y_hits_tr.end(),[&](const double& y) {
-                            return y > y_cut_tmp;
-                        }), y_hits_tr.end());
-                        
-                        row_cut = y_pix - (int)((randcut-config.getDouble("exposure_time")) * static_cast<double>(y_pix) / readout_time);
-                        
-                        //DEBUG
-                        //cout<<"y_cut_tmp = "<<y_cut_tmp<<endl;
-                        //cout<<"row_cut = "<<row_cut<<endl;
-                        //cout<<"sizes = ["<< x_hits_tr.size()<<","<<y_hits_tr.size()<<","
-                        //    <<z_hits_tr.size()<<","<<energy_hits.size()<<"]"<<endl;
-                    
-                    }
-                    if(x_hits_tr.size()==0){
-                        cut_energy = 0;
-                        cout<<"The track was completely cut"<<endl;
-                        TH2I final_image(Form("pic_run%d_ev%d", runCount, entry-start), "",
-                                            x_pix, -0.5, x_pix -0.5,
-                                            y_pix, -0.5, y_pix -0.5);
-                        
-                        for(unsigned int xx =0; xx < background.size(); xx++) {
-                            for(unsigned int yy =0; yy < background[0].size(); yy++) {
-                                final_image.SetBinContent(xx+1, yy+1, background[xx][yy]);
-                            }
-                        }
-                        // Make sure nRedpix matches
-                        nRedpix = redpix_ix->size();
-                        
-                        outtree->Fill();
-                        outfile->cd();
-                        if(!config.getBool("redpix_output")) {
-                            final_image.Write();
-                        }
-                        
-                        continue;
-                    }
-                }
-                    
-                vector<vector<double>> array2d_Nph(x_pix,
-                                                    vector<double>(y_pix, 0.0));
+                vector<vector<double>> array2d_Nph(x_pix, vector<double>(y_pix, 0.0));
                 
                 auto ta = std::chrono::steady_clock::now();
                 // with saturation
@@ -1029,8 +920,13 @@ void DigitizationRunner::processRootFiles() {
                                                         array2d_Nph
                                                         );
                 }
+
+                auto tb = std::chrono::steady_clock::now();
+                std::chrono::duration<double> durtmp=tb-ta;
+                cout << "Time taken in seconds to compute_cmos_with_saturation is: " << durtmp.count() << endl;
                 
-                // Integral of the track - if opt.exposure_effect, it's computed anyway after the cut on the original hits (to save time we digitize only the part that will be visible)
+
+                // Integral of the track - if opt.exposure_effect, it's computed anyway after the cut on the original hits
                 N_photons = accumulate(array2d_Nph.cbegin(), array2d_Nph.cend(), 0, [](auto sum, const auto& row) {
                     return accumulate(row.cbegin(), row.cend(), sum);
                 });
@@ -1044,148 +940,53 @@ void DigitizationRunner::processRootFiles() {
                                                 VignMap);
                 }
                 
+                // Compute always redpix, before possible track cut by exposure of sensor
                 FillRedpix(array2d_Nph, redpix_ix.get(), redpix_iy.get(), redpix_iz.get());
                 
-                if (config.getBool("exposure_time_effect")) { //cut the track post-smearing
-                    if (randcut<readout_time) {
-                        for(unsigned int xx=0; xx < array2d_Nph.size(); xx++) {
-                            for(int yy=0; yy < row_cut; yy++) {
-                                array2d_Nph[xx][yy] = 0.0;
-                            }
-                        }
-                    } else if(randcut> config.getDouble("exposure_time") ) {
-                        for(unsigned int xx=0; xx < array2d_Nph.size(); xx++) {
-                            for(int yy=row_cut; yy < (int)array2d_Nph[0].size(); yy++) {
-                                array2d_Nph[xx][yy] = 0.0;
-                            }
-                        }
-                    }
-                        
-                    //integral after camera exposure cut
+                if (config.getBool("exposure_time_effect")) {
+                    // Cut image and hits
+                    row_cut = processTrack.ApplyExposureCut(array2d_Nph,
+                                                            x_hits_tr,
+                                                            y_hits_tr,
+                                                            z_hits_tr,
+                                                            energy_hits);
+
+                    // Integral after camera exposure cut
                     N_photons_cut = accumulate(array2d_Nph.cbegin(),
                                                 array2d_Nph.cend(), 0, [](auto sum, const auto& row) {
                         return accumulate(row.cbegin(), row.cend(), sum);
                     });
+
+                    // Energy after camera exposure cut
+                    cut_energy = accumulate(energy_hits.begin(), energy_hits.end(), 0.0);
+
                 }
-                
+
+                // Build final TH2I image
                 TH2I final_image(Form("pic_run%d_ev%d", runCount, entry-start), "",
                                     x_pix, -0.5, x_pix -0.5,
                                     y_pix, -0.5, y_pix -0.5);
-                    
                 for(unsigned int xx =0; xx < array2d_Nph.size(); xx++) {
                     for(unsigned int yy =0; yy < array2d_Nph[0].size(); yy++) {
-                        
                         int binc = background[xx][yy]+(int)array2d_Nph[xx][yy];
                         final_image.SetBinContent(xx+1, yy+1, binc);
                     }
                 }
                 
-                //Cut again the hits to save the effective length and energy which is visible in the final image,
-                //and compute the number of photons post-cut
+                // Compute variables (after the cut) to be saved in the tree
                 if (config.getBool("exposure_time_effect")) {
-                    if (randcut<readout_time) {
-                        double y_cut_tmp = config.getDouble("y_dim") * (0.5 - randcut/readout_time);
-
-                        // Removing elements from x_hits_tr
-                        x_hits_tr.erase(std::remove_if(x_hits_tr.begin(), x_hits_tr.end(), [&](const double& x) {
-                            return y_hits_tr[&x-&*x_hits_tr.begin()] < y_cut_tmp;
-                        }), x_hits_tr.end());
-                        // Removing elements from z_hits_tr
-                        z_hits_tr.erase(std::remove_if(z_hits_tr.begin(), z_hits_tr.end(), [&](const double& z) {
-                            return y_hits_tr[&z-&*z_hits_tr.begin()] < y_cut_tmp;
-                            }), z_hits_tr.end());
-                        // Removing elements from energy_hits
-                        energy_hits.erase(std::remove_if(energy_hits.begin(), energy_hits.end(), [&](const double& e) {
-                            return y_hits_tr[&e-&*energy_hits.begin()] < y_cut_tmp;
-                        }), energy_hits.end());
-                        
-                        // Removing elements from y_hits_tr [must be done after the previous ones]
-                        y_hits_tr.erase(std::remove_if(y_hits_tr.begin(), y_hits_tr.end(),[&](const double& y) {
-                            return y < y_cut_tmp;
-                        }), y_hits_tr.end());
-                            
-                    } else if (randcut> config.getDouble("exposure_time") ) {
-                        double y_cut_tmp = config.getDouble("y_dim") * (0.5 - (randcut - config.getDouble("exposure_time")) / readout_time);
-
-                        // Removing elements from x_hits_tr
-                        x_hits_tr.erase(std::remove_if(x_hits_tr.begin(), x_hits_tr.end(), [&](const double& x) {
-                            return y_hits_tr[&x-&*x_hits_tr.begin()] > y_cut_tmp;
-                        }), x_hits_tr.end());
-                        // Removing elements from z_hits_tr
-                        z_hits_tr.erase(std::remove_if(z_hits_tr.begin(), z_hits_tr.end(), [&](const double& z) {
-                            return y_hits_tr[&z-&*z_hits_tr.begin()] > y_cut_tmp;
-                        }), z_hits_tr.end());
-                        // Removing elements from energy_hits
-                        energy_hits.erase(std::remove_if(energy_hits.begin(), energy_hits.end(), [&](const double& e) {
-                            return y_hits_tr[&e-&*energy_hits.begin()] > y_cut_tmp;
-                        }), energy_hits.end());
-                        
-                        // Removing elements from y_hits_tr [must be done after the previous ones]
-                        y_hits_tr.erase(std::remove_if(y_hits_tr.begin(), y_hits_tr.end(),[&](const double& y) {
-                            return y > y_cut_tmp;
-                        }), y_hits_tr.end());
-                        
-                    }
-                        
-                    cut_energy = accumulate(energy_hits.begin(), energy_hits.end(), 0.0);
-                    
-                    if(x_hits_tr.size()==0){
-                        cut_energy = 0;
-                        cout<<"The track was completely cut after smearing"<<endl;
-                            
-                        TH2I final_image_cut(Form("pic_run%d_ev%d", runCount, entry-start), "",
-                                             x_pix, -0.5, x_pix -0.5,
-                                             y_pix, -0.5, y_pix -0.5);
-                            
-                        for(unsigned int xx =0; xx < background.size(); xx++) {
-                            for(unsigned int yy =0; yy < background[0].size(); yy++) {
-                                final_image_cut.SetBinContent(xx+1, yy+1, background[xx][yy]);
-                            }
-                        }
-                        
-                        // Make sure nRedpix matches
-                        nRedpix = redpix_ix->size();
-                        
-                        outtree->Fill();
-                        outfile->cd();
-                        if(!config.getBool("redpix_output")) {
-                            final_image_cut.Write();
-                        }
-                        
-                            
-                        continue;
-                    }
-                        
+                    proj_track_2D_cut = processTrack.GetTrackVariable("proj_track_2D", x_hits_tr, y_hits_tr, z_hits_tr);
+                    x_min_cut = processTrack.GetTrackVariable("x_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                    x_max_cut = processTrack.GetTrackVariable("x_max", x_hits_tr, y_hits_tr, z_hits_tr);
+                    y_min_cut = processTrack.GetTrackVariable("y_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                    y_max_cut = processTrack.GetTrackVariable("y_max", x_hits_tr, y_hits_tr, z_hits_tr);
+                    z_min_cut = processTrack.GetTrackVariable("z_min", x_hits_tr, y_hits_tr, z_hits_tr);
+                    z_max_cut = processTrack.GetTrackVariable("z_max", x_hits_tr, y_hits_tr, z_hits_tr);
                 }
-                
-                
-                // Compute variables to be saved in the tree
-                proj_track_2D_cut = 0;
-                for(int ihit=0; ihit < numhits-1; ihit++){
-                    proj_track_2D_cut += sqrt((x_hits_tr[ihit+1]-x_hits_tr[ihit])*(x_hits_tr[ihit+1]-x_hits_tr[ihit])+
-                                                (y_hits_tr[ihit+1]-y_hits_tr[ihit])*(y_hits_tr[ihit+1]-y_hits_tr[ihit])
-                                                );
-                }
-                // DEBUG
-                //cout<<"proj_track_2D_cut = "<<Form("%.10f", proj_track_2D_cut)<<endl;
-            
-            
-                x_min_cut = (*min_element(x_hits_tr.begin(), x_hits_tr.end()) + 0.5 * config.getDouble("x_dim")) * static_cast<double>(x_pix) / config.getDouble("x_dim");
-                x_max_cut = (*max_element(x_hits_tr.begin(), x_hits_tr.end()) + 0.5 * config.getDouble("x_dim")) * static_cast<double>(x_pix) / config.getDouble("x_dim");
-                y_min_cut = (*min_element(y_hits_tr.begin(), y_hits_tr.end()) + 0.5 * config.getDouble("y_dim")) * static_cast<double>(y_pix) / config.getDouble("y_dim");
-                y_max_cut = (*max_element(y_hits_tr.begin(), y_hits_tr.end()) + 0.5 * config.getDouble("y_dim")) * static_cast<double>(y_pix) / config.getDouble("y_dim");
-                z_min_cut = min((*max_element(z_hits_tr.begin(),
-                                                    z_hits_tr.end()) + config.getDouble("z_extra")),
-                                (*min_element(z_hits_tr.begin(),
-                                                    z_hits_tr.end()) + config.getDouble("z_extra")));
-                z_max_cut = max((*max_element(z_hits_tr.begin(),
-                                                    z_hits_tr.end()) + config.getDouble("z_extra")),
-                                (*min_element(z_hits_tr.begin(),
-                                                    z_hits_tr.end()) + config.getDouble("z_extra")));
                 //DEBUG
+                //cout<<"proj_track_2D_cut = "<<Form("%.10f", proj_track_2D_cut)<<endl;
                 //cout<<" x_min_cut = "<<x_min_cut<<" x_max_cut = "<<x_max_cut<<" y_min_cut = "<<y_minv<<" y_max_cut = "<<y_max_cut<<" z_min_cut = "<<z_min_cut<<" z_max_cut = "<<z_max_cut<<endl;
-            
-            
+
                 // if there are at least 2 hits compute theta and phi
                 if(x_hits_tr.size() > 1) {
                     phi   = atan2( y_hits_tr[1] - y_hits_tr[0],
@@ -1209,9 +1010,9 @@ void DigitizationRunner::processRootFiles() {
                     pz              = (*pz_particle)[0];
                 }
             
-                auto tb = std::chrono::steady_clock::now();
-                std::chrono::duration<double> durtmp=tb-ta;
-                cout << "Time taken in seconds to compute_cmos_with_saturation is: " << durtmp.count() << endl;
+                auto tc = std::chrono::steady_clock::now();
+                std::chrono::duration<double> durtmpc=tc-ta;
+                cout << "Total time taken in seconds to digitize track is: " << durtmpc.count() << endl;
                     
                 // Make sure nRedpix matches
                 nRedpix = redpix_ix->size();


### PR DESCRIPTION
This update completes the addition of redpixes generated by the digitization. Below the different fixes and upgrades:

1. Additions to `TrackProcessor`:
  * `ApplyExposureCut` method to apply the camera exposure cut to both image and MC hits
  * `GetTrackVariable` method to compute track variables (e.g. x_min, x_max, etc.): this helps simplifying and reordering the operations that will be executed in `DigitizationRunner::processRootFiles`
  * `varname_map` map to associate a unique int code to each possible variable name (the map is used only by `GetTrackVariable`)
2. Modification to `DigitizationRunner::processRootFiles`:
  * the redpixes are now saved only uncut, namely the track is always completely digitized
  * the cut procedure is moved after track vignetting
  * implementation of cut procedure and track variable computation done using the new methods of `TrackProcessor` class
3. Modification to `joinPeds`:
  * Complete refurbishment of `joinPeds.cxx` code to follow the same structure as the `main.cxx` file
  * the `joinPeds` executable take as an input the directory where the `digi_RunXXXXX.root` file is, and the output directory where to put the correspondent `histograms_RunXXXXX.root` file (as usual `XXXXX` is the digitization run number)
  * the `joinPeds` takes as an input the same config file used by the digitization
  * suggested usage: `./joinPeds ../config/ConfigFile_new.txt -O ../OutDir/<your-path>/ -I ../OutDir/<your-path>/`
4. Modification to `CMakeLists.txt` to link the `digitizationpp` libraries to the new `joinPeds` executable
5. Modifications and additions to `DigitizationRunner` library for the new joinPeds code:
  * `runPedsOnly` method as the `joinPeds` runner method
  * `isValidDigiFile` method to check if a certain filename is a valid `digi_RunXXXXX.root` file
  * `extractDigiRunNumber` method to extract the `XXXXX` digitization run number from input filename
  * `addPedsToParamDir` method to add the run numbers of the pedestal files in the `param_dir/pedestal_run` histogram 
  * `generateHistogramsFromDigi` method: it is the core of `DigitizationRunner::runPedsOnly ` (as `DigitizationRunner::processRootFiles` is the core of `DigitizationRunner::run`)
  * Modification to `AddBckg` method: now it executes the algorithm for pedestal download/merge/extraction independently of the `bckg` flag in the config file. This means that the check for that flag being true must be called before executing `AddBckg`. Indeed the `processRootFiles` have been modified accordingly.
6. Addition of suggested usage for `joinPeds` in the `README.md` file.