### PR TITLE
Update: give just a warning when encountering negative drift length hits

### DIFF
--- a/include/TrackProcessor.h
+++ b/include/TrackProcessor.h
@@ -115,6 +115,10 @@ public:
                              std::vector<double>& y_hits_tr,
                              std::vector<double>& z_hits_tr);
 
+     int GetN_primaries_reaching_GEMs() {
+         return N_primaries_reaching_GEMs;
+     }
+
 private:
     ConfigManager& config; ///< Reference to configuration
 
@@ -247,6 +251,7 @@ private:
         {"z_max",         12}
     };
 
+    int N_primaries_reaching_GEMs;
 
 
 };

--- a/include/TrackProcessor.h
+++ b/include/TrackProcessor.h
@@ -42,8 +42,10 @@ public:
      * @param[in] energy Total event energy.
      * @param[in] NR_flag Flag indicating if the event is a nuclear recoil.
      * @param[in] image 2D image to be filled with the simulated event.
+     *
+     * @return False is track has to be skipped for some reason (e.g. negative drift length)
      */
-    void computeWithSaturation(const std::vector<double>& x_hits_tr,
+    bool computeWithSaturation(const std::vector<double>& x_hits_tr,
                                const std::vector<double>& y_hits_tr,
                                const std::vector<double>& z_hits_tr,
                                const std::vector<double>& energy_hits_tr,
@@ -60,8 +62,10 @@ public:
      * @param[in] z_hits_tr Vector of z coordinates of energy deposits.
      * @param[in] energy_hits_tr Energy deposited at each hit.
      * @param[in] image 2D image to be filled with the simulated event.
+     *
+     * @return False is track has to be skipped for some reason (e.g. negative drift length)
      */
-    void computeWithoutSaturation(const std::vector<double>& x_hits_tr,
+    bool computeWithoutSaturation(const std::vector<double>& x_hits_tr,
                                   const std::vector<double>& y_hits_tr,
                                   const std::vector<double>& z_hits_tr,
                                   const std::vector<double>& energy_hits_tr,
@@ -123,8 +127,10 @@ private:
      * @param[in] S3D_x Vector of x coordinates of smeared electrons.
      * @param[in] S3D_y Vector of y coordinates of smeared electrons.
      * @param[in] S3D_z Vector of z coordinates of smeared electrons.
+     * 
+     * @return False is track has to be skipped for some reason (e.g. negative drift length)
      */
-    void cloud_smearing3D(  const std::vector<double>& x_hits_tr,
+    bool cloud_smearing3D(  const std::vector<double>& x_hits_tr,
                             const std::vector<double>& y_hits_tr,
                             const std::vector<double>& z_hits_tr,
                             const std::vector<double>& energy_hits_tr,
@@ -175,8 +181,10 @@ private:
      * @param[in] energy_hits_tr Energy deposited at each hit.
      * @param[in] S2D_x Vector of x coordinates of smeared electrons.
      * @param[in] S2D_y Vector of y coordinates of smeared electrons.
+     * 
+     * @return False is track has to be skipped for some reason (e.g. negative drift length)
      */
-    void ph_smearing2D( const std::vector<double>& x_hits_tr,
+    bool ph_smearing2D( const std::vector<double>& x_hits_tr,
                         const std::vector<double>& y_hits_tr,
                         const std::vector<double>& z_hits_tr,
                         const std::vector<double>& energy_hits_tr,
@@ -194,7 +202,7 @@ private:
     std::vector<double> NelGEM1(const std::vector<double>& N_ioniz_el);
 
     /**
-     * @brief Applies GEM2 gain and charge losses to electrons based on z position.
+     * @brief Applies GEM2 gain and charge losses to electrons based on z position. Returns empty vector if the track has hits with negative drift length
      */
     std::vector<double> NelGEM2(const std::vector<double>& energyDep,const std::vector<double>& drift_l);
 

--- a/src/DigitizationRunner.cxx
+++ b/src/DigitizationRunner.cxx
@@ -75,7 +75,7 @@ DigitizationRunner::DigitizationRunner(const std::string& configFile_,
 void DigitizationRunner::run() {
     auto t0 = std::chrono::steady_clock::now();
 
-    setSeed();
+    setSeed(3);
     
     processRootFiles();
 
@@ -87,7 +87,7 @@ void DigitizationRunner::run() {
 void DigitizationRunner::runPedsOnly() {
     auto t0 = std::chrono::steady_clock::now();
 
-    setSeed();
+    setSeed(3);
 
     generateHistogramsFromDigi();
 
@@ -647,6 +647,7 @@ void DigitizationRunner::processRootFiles() {
             Float_t proj_track_2D = -1;
             Int_t nhits_og = -1;
             Int_t N_photons = -1;
+            Int_t N_primaries_reaching_GEMs = -1;
                 
             Int_t row_cut = -1;
             Int_t N_photons_cut = -1;
@@ -689,6 +690,7 @@ void DigitizationRunner::processRootFiles() {
             outtree->Branch("z_min", &z_min, "z_min/F");
             outtree->Branch("z_max", &z_max, "z_max/F");
             outtree->Branch("N_photons", &N_photons, "N_photons/I");
+            outtree->Branch("N_primaries_reaching_GEMs", &N_primaries_reaching_GEMs, "N_primaries_reaching_GEMs/I");
             outtree->Branch("px", &px, "px/F");
             outtree->Branch("py", &py, "py/F");
             outtree->Branch("pz", &pz, "pz/F");
@@ -791,6 +793,7 @@ void DigitizationRunner::processRootFiles() {
                 z_min           = -1;
                 z_max           = -1;
                 N_photons       =  0;
+                N_primaries_reaching_GEMs = -1;
                 x_min_cut       = -1;
                 x_max_cut       = -1;
                 y_min_cut       = -1;
@@ -1073,6 +1076,8 @@ void DigitizationRunner::processRootFiles() {
                 });
                 // DEBUG
                 cout<<"N_photons = "<<N_photons<<endl;
+
+                N_primaries_reaching_GEMs = processTrack.GetN_primaries_reaching_GEMs();
                 
                 // Compute always redpix, before possible track cut by exposure of sensor
                 FillRedpix(array2d_Nph, redpix_ix.get(), redpix_iy.get(), redpix_iz.get());

--- a/src/DigitizationRunner.cxx
+++ b/src/DigitizationRunner.cxx
@@ -33,14 +33,20 @@ DigitizationRunner::DigitizationRunner(const std::string& configFile_,
       inputDir(inputDir_),
       outputDir(outputDir_)
 {
+    
+    
     if (!config.loadConfig(configFile)) {
         cerr << "Failed to load configuration file: " << configFile << endl;
         exit(EXIT_FAILURE);
     }
+    
 
     config.validateAxisMappings();
 
+    
+
     runCount = config.getInt("start_run_number");
+    
 
     // DEBUG
     //config.printConfig();
@@ -70,7 +76,7 @@ void DigitizationRunner::run() {
     auto t0 = std::chrono::steady_clock::now();
 
     setSeed();
-
+    
     processRootFiles();
 
     auto t1 = std::chrono::steady_clock::now();
@@ -985,23 +991,75 @@ void DigitizationRunner::processRootFiles() {
                 // with saturation
                 if(config.getBool("saturation")) {
                     cout<<"Starting compute_cmos_with_saturation with size = "<<x_hits_tr.size()<<"..."<<endl;
-                    processTrack.computeWithSaturation(x_hits_tr,
-                                                        y_hits_tr,
-                                                        z_hits_tr,
-                                                        energy_hits,
-                                                        VignMap,
-                                                        energy,
-                                                        NR_flag,
-                                                        array2d_Nph
-                                                        );
+                    if(!processTrack.computeWithSaturation(x_hits_tr,
+                                                           y_hits_tr,
+                                                           z_hits_tr,
+                                                           energy_hits,
+                                                           VignMap,
+                                                           energy,
+                                                           NR_flag,
+                                                           array2d_Nph
+                                                           )) {
+                        std::cerr<<"Warning: DigitizationRunner::processRootFiles: skipping this track because of error from TrackProcessor::computeWithSaturation."<<std::endl;
+
+                        // The reported energy is -1 for those tracks to be recognizable
+                        energy = -1;
+                        TH2I final_image(Form("pic_run%d_ev%d", runCount, entry-start), "",
+                                            x_pix, -0.5, x_pix -0.5,
+                                            y_pix, -0.5, y_pix -0.5);
+                        
+                        for(unsigned int xx =0; xx < background.size(); xx++) {
+                            for(unsigned int yy =0; yy < background[0].size(); yy++) {
+                                final_image.SetBinContent(xx+1, yy+1, background[xx][yy]);
+                            }
+                        }
+    
+                        // Make sure nRedpix matches
+                        nRedpix = redpix_ix->size();
+                        
+                        outtree->Fill();
+                        outfile->cd();
+                        if(!config.getBool("redpix_output")) {
+                            final_image.Write();
+                        }
+                        
+                        continue;
+                        
+                    }
                     
                 } else {// no saturation [Fixme: not updated]
-                    processTrack.computeWithoutSaturation(x_hits_tr,
+                    if(!processTrack.computeWithoutSaturation(x_hits_tr,
                                                         y_hits_tr,
                                                         z_hits_tr,
                                                         energy_hits,
                                                         array2d_Nph
-                                                        );
+                                                        )) {
+                        std::cerr<<"Warning: DigitizationRunner::processRootFiles: skipping this track because of error from TrackProcessor::computeWithoutSaturation."<<std::endl;
+
+                        // The reported energy is -1 for those tracks to be recognizable
+                        energy = -1;
+                        TH2I final_image(Form("pic_run%d_ev%d", runCount, entry-start), "",
+                                            x_pix, -0.5, x_pix -0.5,
+                                            y_pix, -0.5, y_pix -0.5);
+                        
+                        for(unsigned int xx =0; xx < background.size(); xx++) {
+                            for(unsigned int yy =0; yy < background[0].size(); yy++) {
+                                final_image.SetBinContent(xx+1, yy+1, background[xx][yy]);
+                            }
+                        }
+    
+                        // Make sure nRedpix matches
+                        nRedpix = redpix_ix->size();
+                        
+                        outtree->Fill();
+                        outfile->cd();
+                        if(!config.getBool("redpix_output")) {
+                            final_image.Write();
+                        }
+                        
+                        continue;
+                        
+                    }
                 }
                 cout<<"DEBUG: after compute"<<endl<<flush;
                 auto tb = std::chrono::steady_clock::now();

--- a/src/TrackProcessor.cxx
+++ b/src/TrackProcessor.cxx
@@ -30,7 +30,9 @@
 using namespace std;
 
 TrackProcessor::TrackProcessor(ConfigManager& configMgr)
-    : config(configMgr) {}
+    : config(configMgr) {
+        N_primaries_reaching_GEMs = -1;
+    }
 
 bool TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
                                            const vector<double>& y_hits_tr,
@@ -449,19 +451,19 @@ bool TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
         std::cout << "Time smear " << dur_smear.count() << " seconds" <<std::endl;
         std::cout << "Time Critical " << dur_criti.count() << " seconds" <<std::endl;
         std::cout << "Time ampli " << dur_ampli.count() << " seconds" <<std::endl;
-
+        
         // Padding [Now before camera digitization because needed for VignMap]
         // FIXME: Write a function padding()
         //Define a translation vector
         
         // DEBUG
-        //int sommatotale =0;
-        //
-        //sommatotale = accumulate(hout.cbegin(), hout.cend(), 0, [](auto sum, const auto& row) {
-        //            return accumulate(row.cbegin(), row.cend(), sum);
-        //        });
-        //
-        //cout<<"INT = "<<sommatotale<<endl;
+        // int sommatotale =0;
+        
+        // sommatotale = accumulate(hout.cbegin(), hout.cend(), 0, [](auto sum, const auto& row) {
+        //             return accumulate(row.cbegin(), row.cend(), sum);
+        //         });
+        
+        // cout<<"DEBUG: INT = "<<sommatotale<<endl;
 
         int x_center_cloud=(int)round(((xmax+xmin)/2.)/xbin_dim);
         int y_center_cloud=(int)round(((ymax+ymin)/2.)/ybin_dim);
@@ -658,6 +660,9 @@ void TrackProcessor::smear_parallel(const vector<double>& x_axis_hit,const vecto
     X.reserve(nelsum);
     Y.reserve(nelsum);
     Z.reserve(nelsum);
+
+    // Fixed random seed
+    bool fixedSeed = config.getBool("fixed_seed");
     
     // Create a vector of indices where each index i is repeated nel[i] times
     vector<long int> indices(nelsum);
@@ -685,7 +690,9 @@ void TrackProcessor::smear_parallel(const vector<double>& x_axis_hit,const vecto
             vector<float> x_paralvec,y_paralvec,z_paralvec;
             TRandom3 paralrandom;
             myMutex.lock();
-            paralrandom.SetSeed(floor(gRandom->Rndm()*10000));
+            //deterministic seed from chunk start
+            if(fixedSeed) paralrandom.SetSeed(3+static_cast<UInt_t>(range.begin()));
+            else paralrandom.SetSeed(floor(gRandom->Rndm()*10000));
             myMutex.unlock();
             for(auto iterator=range.begin();iterator<range.end();++iterator)
             {
@@ -753,6 +760,10 @@ vector<double> TrackProcessor::NelGEM2(const vector<double>& energyDep, const ve
     transform(n_ioniz_el_mean.begin(), n_ioniz_el_mean.end(), n_ioniz_el.begin(), [&] (double a) {
         return gRandom->Poisson(a);
     });
+
+    N_primaries_reaching_GEMs = std::accumulate(n_ioniz_el.begin(), n_ioniz_el.end(), 0.0);
+    std::cout << "Number of primaries reaching GEMs: " << N_primaries_reaching_GEMs << std::endl;
+    
     
     // total number of secondary electrons considering the gain in the 2nd GEM foil
     vector<double> n_tot_el = NelGEM1(n_ioniz_el);

--- a/src/TrackProcessor.cxx
+++ b/src/TrackProcessor.cxx
@@ -32,7 +32,7 @@ using namespace std;
 TrackProcessor::TrackProcessor(ConfigManager& configMgr)
     : config(configMgr) {}
 
-void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
+bool TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
                                            const vector<double>& y_hits_tr,
                                            const vector<double>& z_hits_tr,
                                            const vector<double>& energy_hits,
@@ -47,7 +47,7 @@ void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
     vector<float> S3D_z;
     
     // if there are no electrons on GEM3, just use empty image
-    if (x_hits_tr.size() == 0) return;
+    if (x_hits_tr.size() == 0) return true;
     // if there are electrons on GEM3, apply saturation effect
     else {
         double OFF = 15;
@@ -200,7 +200,10 @@ void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
             } else {
 
                 auto startsmear = std::chrono::steady_clock::now();
-                cloud_smearing3D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S3D_x, S3D_y, S3D_z);
+                if(!cloud_smearing3D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S3D_x, S3D_y, S3D_z)) {
+                    std::cerr << "Warning: TrackProcessor::computeWithSaturation: skipping this track because of error from TrackProcessor::cloud_smearing3D."<<std::endl;
+                    return false;
+                }
                 auto endsmear = std::chrono::steady_clock::now();
                 dur_smear=dur_smear+endsmear-startsmear;
                 size_tot+=S3D_z.size();
@@ -316,7 +319,10 @@ void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
                         
                         //cout<<"Smearing..."<<endl<<flush;
                         auto startsmear = std::chrono::steady_clock::now();
-                        cloud_smearing3D(x_hits_tr_i, y_hits_tr_i, z_hits_tr_i, energy_hits_i, S3D_x, S3D_y, S3D_z);
+                        if(!cloud_smearing3D(x_hits_tr_i, y_hits_tr_i, z_hits_tr_i, energy_hits_i, S3D_x, S3D_y, S3D_z)) {
+                            std::cerr << "Warning: TrackProcessor::computeWithSaturation: skipping this track because of error from TrackProcessor::cloud_smearing3D."<<std::endl;
+                            return false;
+                        }
                         auto endsmear = std::chrono::steady_clock::now();
                         dur_smear=dur_smear+endsmear-startsmear;
                         size_tot+=S3D_z.size();
@@ -376,7 +382,10 @@ void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
 
                 } else {
                     auto startsmear = std::chrono::steady_clock::now();
-                    cloud_smearing3D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S3D_x, S3D_y, S3D_z);
+                    if(!cloud_smearing3D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S3D_x, S3D_y, S3D_z)) {
+                        std::cerr << "Warning: TrackProcessor::computeWithSaturation: skipping this track because of error from TrackProcessor::cloud_smearing3D."<<std::endl;
+                        return false;
+                    }
                     auto endsmear = std::chrono::steady_clock::now();
                     dur_smear=dur_smear+endsmear-startsmear;
                     size_tot+=S3D_z.size();
@@ -522,12 +531,12 @@ void TrackProcessor::computeWithSaturation(const vector<double>& x_hits_tr,
         }
         
     }
-    return;
+    return true;
 
 
 }
 
-void TrackProcessor::computeWithoutSaturation(const std::vector<double>& x_hits_tr,
+bool TrackProcessor::computeWithoutSaturation(const std::vector<double>& x_hits_tr,
                                               const std::vector<double>& y_hits_tr,
                                               const std::vector<double>& z_hits_tr,
                                               const std::vector<double>& energy_hits,
@@ -538,7 +547,10 @@ void TrackProcessor::computeWithoutSaturation(const std::vector<double>& x_hits_
 
     vector<float> S2D_x;
     vector<float> S2D_y;
-    ph_smearing2D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S2D_x, S2D_y);      //Function still to be corrected
+    if(!ph_smearing2D(x_hits_tr, y_hits_tr, z_hits_tr, energy_hits, S2D_x, S2D_y)) {      //Function still to be corrected
+        std::cerr << "Warning: TrackProcessor::computeWithoutSaturation: skipping this track because of error from TrackProcessor::ph_smearing2D."<<std::endl;
+        return false;
+    }
 
     // Vector to store all indices
     vector<size_t> indices(S2D_x.size());
@@ -568,10 +580,10 @@ void TrackProcessor::computeWithoutSaturation(const std::vector<double>& x_hits_
 
     image = signal;
 
-    return;
+    return true;
 }
 
-void TrackProcessor::cloud_smearing3D(const vector<double>& x_hits_tr,
+bool TrackProcessor::cloud_smearing3D(const vector<double>& x_hits_tr,
                                       const vector<double>& y_hits_tr,
                                       const vector<double>& z_hits_tr,
                                       const vector<double>& energy_hits,
@@ -580,6 +592,11 @@ void TrackProcessor::cloud_smearing3D(const vector<double>& x_hits_tr,
                                       vector<float>& S3D_z) {
 
     vector<double> nel = NelGEM2(energy_hits, z_hits_tr);
+    if (nel.empty()) {
+        std::cerr << "Warning: TrackProcessor::cloud_smearing3D: skipping this track because of empty result from TrackProcessor::NelGEM2."<<std::endl;
+        return false;
+    }
+    
     //DEBUG
     //for(unsigned int i=0; i<nel.size(); i++) {
     //    cout<<nel[i]<<"\n";
@@ -601,7 +618,7 @@ void TrackProcessor::cloud_smearing3D(const vector<double>& x_hits_tr,
     //    cout<<S3D_x[i]<<endl;
     //}
 
-    return;
+    return true;
 }
 
 
@@ -723,7 +740,8 @@ vector<double> TrackProcessor::NelGEM2(const vector<double>& energyDep, const ve
     transform(drift_l.begin(), drift_l.end(), negatives.begin(),
               [](int x) { return x < 0; });
     if (any_of(negatives.begin(), negatives.end(), [](bool b) { return b; })) {
-        throw runtime_error("TrackProcessor::NelGEM2: track contains hits with negative drift length.\n");
+        std::cerr << "Warning: TrackProcessor::NelGEM2: track contains hits with negative drift length."<<std::endl;
+        return {};  // empty vector signals "skip"
     }
     
     vector<double> n_ioniz_el_mean(n_ioniz_el_ini.size(), 0.0);
@@ -772,7 +790,7 @@ double TrackProcessor::Nph_saturation(int nel, double A, double beta) {
 }
 
 
-void TrackProcessor::ph_smearing2D( const vector<double>& x_hits_tr,                        //Function still to be corrected
+bool TrackProcessor::ph_smearing2D( const vector<double>& x_hits_tr,                        //Function still to be corrected
                                     const vector<double>& y_hits_tr,
                                     const vector<double>& z_hits_tr,
                                     const vector<double>& energy_hits,
@@ -781,6 +799,10 @@ void TrackProcessor::ph_smearing2D( const vector<double>& x_hits_tr,            
 
     // Electrons in GEM2
     vector<double> nel = NelGEM2(energy_hits, z_hits_tr);
+    if (nel.empty()) {
+        std::cerr << "Warning: TrackProcessor::ph_smearing2D: skipping this track because of empty result from TrackProcessor::NelGEM2."<<std::endl;
+        return false;
+    }
 
     double optphotons_per_el    = config.getDouble("photons_per_el");
     double optA                 = config.getDouble("A");
@@ -796,7 +818,7 @@ void TrackProcessor::ph_smearing2D( const vector<double>& x_hits_tr,            
     S2D_x = smear(x_hits_tr, sigma_xy, nph);
     S2D_y = smear(y_hits_tr, sigma_xy, nph);
 
-    return;
+    return true;
 }
 
 void TrackProcessor::TrackVignetting(vector<vector<double>>& image, int xpix, int ypix, const TH2F & VignMap) {


### PR DESCRIPTION
## What's Changed

I propose a modification of the code to let the code be able to address negative drift length tracks, i.e. tracks with hits at negative z. The previous version of the code treated this case as an error and exited the program, now:

- a warning is printed on the `stderr`
- the energy of the track is set to -1
- the redPixels are empty and any generated image is an empty image (namely just pedestal)

Technically speaking:

- Now most of the methods in the `TrackProcessor` class are not void but instead returning boolean flag (true = success, false = fault)
- The .h and .cxx files changed accordingly, as well as the doxygen-style documentation of the modified methods
- The `DigitizationRunner` class was changed to catch any possible issue with track processing and eventually retrieve an empty track with energy equal to -1

Other improvements:
- Bugfix: the seed of the rng of the simulation is now really fixed by the correspondent option in the config file
- Addition a branch to the output tree called `N_primaries_reaching_GEMs` reporting the number of primary electrons that survive the diffusion process and reach the GEM plane before amplification